### PR TITLE
fix: tighten thor-seed execution behavior

### DIFF
--- a/thor-seed/README.md
+++ b/thor-seed/README.md
@@ -19,6 +19,7 @@ The script itself writes an extensive log named `thor-seed.log`. You can deactiv
 ## Requirements
 
 - PowerShell version 3
+- PowerShell FullLanguage mode
 - 70 MB of temporary disk space
 - Network connection to a THOR source (ASGARD, Nextron cloud servers, THOR/THOR Lite as ZIP on a web server)
 
@@ -48,6 +49,12 @@ For details on how to create such a package, see [custom THOR package](#custom-t
 thor-seed.ps1 -CustomUrl https://web1.internal/thor/mythor-pack.zip
 ```
 
+If more than one THOR source is configured, THOR Seed uses the following precedence and prints a warning that explains which source is selected:
+
+1. `-AsgardServer`
+2. `-UseCloud`
+3. `-CustomUrl`
+
 ## Parameters
 
 ### -AsgardServer
@@ -76,15 +83,21 @@ Use this API key for the upload to the Analysis Cockpit. We recommend that you c
 
 ### -CustomUrl
 
-Allows you to define a custom URL from which the THOR package is retrieved. Make sure that the package contains the full program folder, provide it as ZIP archive and add valid licenses (Incident Response license, THOR Lite license). THOR Seed will automaticall find the THOR binaries in the extracted archive.
+Allows you to define a custom URL from which the THOR package is retrieved. Make sure that the package contains the full program folder, provide it as ZIP archive and add valid licenses (Incident Response license, THOR Lite license). THOR Seed will automatically find the THOR binaries in the extracted archive.
 
 ### -RandomDelay
 
 A random delay in seconds before the scan starts. This is helpful when you start the script on thousands of end systems to avoid system (VM host) or network (package retrieval) overload by distributing the load over a defined time range.
 
+### -CpuLimit
+
+Limit THOR CPU usage by passing `--cpulimit <value>` to THOR. The value must be between 1 and 100.
+
 ### -OutputPath
 
 The output path is a custom directory to write all output files to (default is the script's directory). Output files include a text log, an HTML report and a CSV file for all filescan findings regarded as suspicious or malicious.
+
+When preset configs are enabled, THOR Seed also writes this effective output path into the generated THOR config as `rebase-dir`.
 
 ### -NoLog
 
@@ -102,13 +115,17 @@ Removes all log and report files of previous scans
 
 Ignore connection errors caused by self-signed certificates
 
+### -NoResControl
+
+Disable THOR resource safeguards by passing `--norescontrol` to THOR. This is an advanced option and can increase the risk of swapping and system performance impact.
+
 ### -ProxyAddress
 
 Proxy address to use format: http://host:port
 
 ### -ProxyCredentials
 
-Proxy credentials to authenticate. Bye default Empty.
+Proxy credentials to authenticate. By default empty.
 
 ## Preconfigured Variables
 
@@ -148,7 +165,7 @@ module:
   - FileScan
   - ProcessCheck
   - Eventlog
-nosoft: true       # Don't trottle the scan, even on single core systems
+nosoft: true       # Don't throttle the scan, even on single core systems
 lookback: 1        # Log and Eventlog look back time in days
 sigma: true        # Activate Sigma scanning on Eventlogs
 quick: true        # Quick scan mode
@@ -161,9 +178,9 @@ nothordb: true     # Don't create a local SQLite database for differential analy
 
 ## THOR Lite
 
-THOR Lite is a trimmed-down free version of our scanner THOR. Your can find more information and a download form [here](https://www.nextron-systems.com/thor-lite/). THOR Seed works with a THOR Lite package provided as ZIP archive on a web server. Make sure to add a valid THOR Lite license to that ZIP archive.
+THOR Lite is a trimmed-down free version of our scanner THOR. You can find more information and a download form [here](https://www.nextron-systems.com/thor-lite/). THOR Seed works with a THOR Lite package provided as ZIP archive on a web server. Make sure to add a valid THOR Lite license to that ZIP archive.
 
-The cutoms THOR Lite package can be used as follows:
+The custom THOR Lite package can be used as follows:
 
 ```console
 thor-seed.ps1 -CustomUrl https://web1.internal/thor/thor10lite-with-lic.zip
@@ -180,6 +197,8 @@ In order to prepare a custom package you have to repack the THOR package that yo
 ![THOR Seed Custom Package](https://raw.githubusercontent.com/NextronSystems/nextron-helper-scripts/master/images/thor_seed_custom_zip.png "Prepare a custom THOR package with license")
 
 Make sure to check the description on [preconfigured variables](#preconfigured-variables) and the YAML config templates.
+
+THOR Seed executes THOR from the directory in which it finds the THOR binary. Keep relative resource directories such as `config`, `custom-signatures` and `signatures` next to the THOR binaries inside the package.
 
 You can remove some folders to save disk space and reduce network load when running the script on thousands of systems. The required files and directories are the following. You can safely remove all other files and directories.
 
@@ -222,7 +241,7 @@ You can remove some folders to save disk space and reduce network load when runn
     └── upx.exe.sig
 ```
 
-Importan: The listing above does not include the license file, which is obviously also required.
+Important: The listing above does not include the license file, which is obviously also required.
 
 ## Microsoft Defender ATP
 
@@ -230,7 +249,7 @@ We use THOR Seed with [Microsoft Defender ATP](https://docs.microsoft.com/en-us/
 
 ### Issue with Live Response Session in Microsoft Defender ATP
 
-There are some pitfalls that I'd like to highlight when running THOR in live response sessions. The first problem is the different command line. All parameters for THOR Seed have to be passed as string of a seperate parameter of the tool "run".
+There are some pitfalls that I'd like to highlight when running THOR in live response sessions. The first problem is the different command line. All parameters for THOR Seed have to be passed as string of a separate parameter of the tool "run".
 
 ```console
 run thor-seed.ps1 -parameters "-CustomUrl https://my.server.local/share/thor-pack.zip"
@@ -250,6 +269,18 @@ lookback: 2 # scan only elements created or changed within the last 2 days
 ```
 
 ## Helpful Hints
+
+### PowerShell Language Mode
+
+THOR Seed requires PowerShell FullLanguage mode. It uses .NET APIs for TLS handling, downloads, ZIP extraction and process setup. If App Control for Business / WDAC, AppLocker, JEA or endpoint security policy restrictions force the session into ConstrainedLanguage mode, THOR Seed cannot run reliably.
+
+You can check the current language mode with:
+
+```powershell
+$ExecutionContext.SessionState.LanguageMode
+```
+
+For details, see Microsoft's [script enforcement documentation](https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/design/script-enforcement).
 
 ### Unblocking the Script
 
@@ -283,6 +314,10 @@ powershell.exe -ExecutionPolicy Bypass .\thor-seed.ps1 -CustomUrl https://my-web
 ```console
 powershell.exe -ExecutionPolicy Bypass .\thor-seed.ps1 -AsgardServer asgard1.internal -Token 74y47Wjw3wWRKlmBu4EUWFzGY-QWgdmzRZ -IgnoreSSLErrors
 ```
+
+### Exit Codes
+
+THOR Seed returns `0` on success. It returns a nonzero exit code if a preflight check, download, extraction, scan execution or Analysis Cockpit upload fails. This allows deployment tooling and live response automation to detect failed runs reliably.
 
 ### Quick Web Server Setup
 

--- a/thor-seed/README.md
+++ b/thor-seed/README.md
@@ -303,6 +303,24 @@ Unblock-File -Path .\thor-seed.ps1
 Get-ChildItem -Path .\thor-seed\ -Recurse | Unblock-File
 ```
 
+You can also unblock the file in Windows Explorer by opening the file properties, enabling `Unblock` and applying the change.
+
+If the prompt appears while running the script, `R` (`Run once`) continues this single run. This does not remove the mark-of-the-web from the file, so Windows may show the same prompt again during the next execution. Use `Unblock-File` if you trust the script and want to avoid repeated prompts.
+
+### Help Output Warning
+
+When THOR Seed is started without a THOR source, it tries to show its PowerShell help text. On systems with incomplete local PowerShell help data or blocked/downloaded script metadata, PowerShell may print a warning similar to:
+
+```console
+Get-Help : Get-Help could not find .\thor-seed.ps1 in a help file in this session.
+```
+
+This warning does not indicate a THOR scan failure. Start THOR Seed with one of the required source parameters, for example `-AsgardServer`, `-UseCloud` or `-CustomUrl`. To view the usage information, use this README or run:
+
+```powershell
+Get-Help .\thor-seed.ps1 -Detailed
+```
+
 ### Execution
 
 If you get the following error message `cannot be loaded because the execution of scripts is disabled on this system` you may run the script as follows:

--- a/thor-seed/thor-seed.ps1
+++ b/thor-seed/thor-seed.ps1
@@ -247,18 +247,18 @@ param
 
 # Fixing Certain Platform Environments --------------------------------
 $AutoDetectPlatform = ""
-if ($OutputPath -eq "")
+if ([string]::IsNullOrWhiteSpace($OutputPath))
 {
     $OutputPath = $PSScriptRoot
 }
 
 # Microsoft Defender ATP - Live Response
 # $PSScriptRoot is empty or contains path to Windows Defender
-if ($OutputPath -eq "" -or $OutputPath.Contains("Windows Defender Advanced Threat Protection"))
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or $OutputPath.Contains("Windows Defender Advanced Threat Protection"))
 {
     $AutoDetectPlatform = "MDATP"
     # Setting output path to easily accessible system root, e.g. C:
-    if ($OutputPath -eq "")
+    if ([string]::IsNullOrWhiteSpace($OutputPath))
     {
         $OutputPath = "$($env:ProgramData)\thor"
     }

--- a/thor-seed/thor-seed.ps1
+++ b/thor-seed/thor-seed.ps1
@@ -245,6 +245,25 @@ param
 # Choose an output directory for all output files (log, HTML report)
 #[string]$OutputPath = "C:\Windows\Temp"
 
+# Fixing Certain Platform Environments --------------------------------
+$AutoDetectPlatform = ""
+if ($OutputPath -eq "")
+{
+    $OutputPath = $PSScriptRoot
+}
+
+# Microsoft Defender ATP - Live Response
+# $PSScriptRoot is empty or contains path to Windows Defender
+if ($OutputPath -eq "" -or $OutputPath.Contains("Windows Defender Advanced Threat Protection"))
+{
+    $AutoDetectPlatform = "MDATP"
+    # Setting output path to easily accessible system root, e.g. C:
+    if ($OutputPath -eq "")
+    {
+        $OutputPath = "$($env:ProgramData)\thor"
+    }
+}
+
 # Predefined YAML Config
 $UsePresetConfig = $True
 # Lines with '#' are commented and inactive. We decided to give you
@@ -330,25 +349,6 @@ Could not get files of directory
 Signature file is older than 60 days
 \\Our-Custom-Software\\v1.[0-9]+\\
 "@
-
-# Fixing Certain Platform Environments --------------------------------
-$AutoDetectPlatform = ""
-if ($OutputPath -eq "")
-{
-    $OutputPath = $PSScriptRoot
-}
-
-# Microsoft Defender ATP - Live Response
-# $PSScriptRoot is empty or contains path to Windows Defender
-if ($OutputPath -eq "" -or $OutputPath.Contains("Windows Defender Advanced Threat Protection"))
-{
-    $AutoDetectPlatform = "MDATP"
-    # Setting output path to easily accessible system root, e.g. C:
-    if ($OutputPath -eq "")
-    {
-        $OutputPath = "$($env:ProgramData)\thor"
-    }
-}
 
 # Global Variables ----------------------------------------------------
 $global:NoLog = $NoLog
@@ -706,6 +706,34 @@ if ($AutoDetectPlatform -ne "")
 {
     Write-Log "Auto Detect Platform: $($AutoDetectPlatform)"
     Write-Log "Note: Some automatic changes have been applied"
+}
+
+# Report source precedence explicitly when more than one THOR source is configured.
+$RequestedThorSources = @()
+if (-not [string]::IsNullOrEmpty($AsgardServer))
+{
+    $RequestedThorSources += "ASGARD (-AsgardServer $AsgardServer)"
+}
+if ($UseCloud)
+{
+    $RequestedThorSources += "Nextron cloud (-UseCloud)"
+}
+if (-not [string]::IsNullOrEmpty($CustomUrl))
+{
+    $RequestedThorSources += "custom URL (-CustomUrl $(Get-RedactedUrl -Url $CustomUrl))"
+}
+if ($RequestedThorSources.Count -gt 1)
+{
+    $SelectedThorSource = "custom URL (-CustomUrl)"
+    if (-not [string]::IsNullOrEmpty($AsgardServer))
+    {
+        $SelectedThorSource = "ASGARD (-AsgardServer $AsgardServer)"
+    }
+    elseif ($UseCloud)
+    {
+        $SelectedThorSource = "Nextron cloud (-UseCloud)"
+    }
+    Write-Log "Multiple THOR sources specified: $($RequestedThorSources -join ', '). Using $SelectedThorSource based on precedence: -AsgardServer, then -UseCloud, then -CustomUrl." -Level "Warning"
 }
 
 # ---------------------------------------------------------------------
@@ -1193,6 +1221,7 @@ if (-not $script:ExecutionFailed)
                 }
             }
             Write-Log "Command Line: $($ThorBinary) $($ScanParametersForLog -join ' ')"
+            Write-Log "Working Directory: $($ThorBinDirectory)"
             Write-Log "Writing output files to $($OutputPath)"
             if (-not (Test-Path -Path $OutputPath))
             {
@@ -1210,12 +1239,12 @@ if (-not $script:ExecutionFailed)
             if ($ScanParameters.Count -gt 0)
             {
                 # With Arguments
-                $p = Start-Process $ThorBinary -ArgumentList $ScanParameters -NoNewWindow -PassThru
+                $p = Start-Process -FilePath $ThorBinary -ArgumentList $ScanParameters -WorkingDirectory $ThorBinDirectory -NoNewWindow -PassThru
             }
             else
             {
                 # Without Arguments
-                $p = Start-Process $ThorBinary -NoNewWindow -PassThru
+                $p = Start-Process -FilePath $ThorBinary -WorkingDirectory $ThorBinDirectory -NoNewWindow -PassThru
             }
             # Cache handle, required to access ExitCode, see https://stackoverflow.com/questions/10262231/obtaining-exitcode-using-start-process-and-waitforexit-instead-of-wait
             $handle = $p.Handle
@@ -1480,3 +1509,4 @@ if ($script:SummaryGuidance.Count -gt 0)
 Write-Log "==========================================================="
 [Environment]::ExitCode = $script:ExitCode
 $global:LASTEXITCODE = $script:ExitCode
+exit $script:ExitCode

--- a/thor-seed/thor-seed.ps1
+++ b/thor-seed/thor-seed.ps1
@@ -2,9 +2,9 @@
 # Script Title: THOR Download and Execute Script
 # Script File Name: thor-seed.ps1
 # Author: Florian Roth
-# Version: 2.0.0
+# Version: 2.0.1
 # Date Created: 13.07.2020
-# Last Modified: 11.02.2026
+# Last Modified: 12.06.2026
 ##################################################
 
 #Requires -Version 3
@@ -654,7 +654,7 @@ Write-Host "   / / / _  / /_/ / , _/ _\ \/ -_) -_) _  /   /_\ /_\      "
 Write-Host "  /_/ /_//_/\____/_/|_| /___/\__/\__/\_,_/    \ / \ /      "
 Write-Host "                                               \   /       "
 Write-Host "  Nextron Systems, by Florian Roth              \_/        "
-Write-Host "  v2.0.0 - Last Modified: 11.02.2026                       "
+Write-Host "  v2.0.1 - Last Modified: 12.06.2026                       "
 Write-Host "==========================================================="
 
 # Measure time


### PR DESCRIPTION
## Summary
- finalize OutputPath before preset YAML is interpolated so rebase-dir matches the effective output path
- log the selected THOR source when multiple source parameters are provided, preserving ASGARD > cloud > custom URL precedence
- start THOR with the extracted binary directory as the working directory and exit the script with the tracked failure code

## Testing
- pwsh -NoProfile -Command '$tokens=$null; $errors=$null; [System.Management.Automation.Language.Parser]::ParseFile("thor-seed/thor-seed.ps1", [ref]$tokens, [ref]$errors) | Out-Null; if ($errors.Count -gt 0) { exit 1 }'
- pwsh -NoProfile -File thor-seed/thor-seed.ps1
- pwsh -NoProfile -File thor-seed/thor-seed.ps1 -CustomUrl http://example.invalid/thor.zip -RandomDelay 0 -NoLog
- pwsh -NoProfile -File thor-seed/thor-seed.ps1 -AsgardServer asgard.local -UseCloud -CustomUrl 'http://example.invalid/thor.zip?token=secret' -Token test-token -RandomDelay 0 -NoLog